### PR TITLE
Add programmatic initialization support

### DIFF
--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockAPI.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/NoteBlockAPI.java
@@ -25,17 +25,154 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class NoteBlockAPI extends JavaPlugin {
 
-	private static NoteBlockAPI plugin;
-	
-	private Map<UUID, ArrayList<SongPlayer>> playingSongs = new ConcurrentHashMap<UUID, ArrayList<SongPlayer>>();
-	private Map<UUID, Byte> playerVolume = new ConcurrentHashMap<UUID, Byte>();
+        private static final ApiState STATE = new ApiState();
 
-	private Scheduler.Task dependencyScanTask;
-	private Scheduler.Task updateCheckTask;
+        private static final class ApiState {
+                private final Map<UUID, ArrayList<SongPlayer>> playingSongs = new ConcurrentHashMap<>();
+                private final Map<UUID, Byte> playerVolume = new ConcurrentHashMap<>();
+                private final Map<Plugin, Boolean> dependentPlugins = new HashMap<>();
 
-	private boolean disabling = false;
-	
-	private HashMap<Plugin, Boolean> dependentPlugins = new HashMap<>();
+                private Scheduler.Task dependencyScanTask;
+                private Scheduler.Task updateCheckTask;
+
+                private boolean disabling = false;
+                private boolean initialized = false;
+
+                private NoteBlockAPI pluginInstance;
+                private JavaPlugin owningPlugin;
+        }
+
+        private static void ensureInitialized(JavaPlugin plugin, boolean pluginManaged) {
+                synchronized (STATE) {
+                        if (STATE.initialized) {
+                                return;
+                        }
+
+                        STATE.initialized = true;
+                        STATE.owningPlugin = plugin;
+                        if (pluginManaged && plugin instanceof NoteBlockAPI) {
+                                STATE.pluginInstance = (NoteBlockAPI) plugin;
+                        }
+
+                        STATE.disabling = false;
+
+                        STATE.dependentPlugins.clear();
+                        for (Plugin pl : Bukkit.getServer().getPluginManager().getPlugins()) {
+                                if (pl.getDescription().getDepend().contains("NoteBlockAPI")
+                                                || pl.getDescription().getSoftDepend().contains("NoteBlockAPI")) {
+                                        STATE.dependentPlugins.put(pl, false);
+                                }
+                        }
+
+                        final Metrics metrics = pluginManaged ? new Metrics(plugin, 1083) : null;
+                        final JavaPlugin owningPlugin = plugin;
+
+                        new NoteBlockPlayerMain().onEnable();
+
+                        STATE.dependencyScanTask = Scheduler.runLater(new Runnable() {
+
+                                @Override
+                                public void run() {
+                                        Plugin[] plugins = Bukkit.getServer().getPluginManager().getPlugins();
+                                        Type[] types = new Type[]{PlayerRangeStateChangeEvent.class, SongDestroyingEvent.class, SongEndEvent.class, SongStoppedEvent.class };
+                                        for (Plugin pl : plugins) {
+                                                ArrayList<RegisteredListener> rls = HandlerList.getRegisteredListeners(pl);
+                                                for (RegisteredListener rl : rls) {
+                                                        Method[] methods = rl.getListener().getClass().getDeclaredMethods();
+                                                        for (Method m : methods) {
+                                                                Type[] params = m.getParameterTypes();
+                                                                param:
+                                                                for (Type paramType : params) {
+                                                                        for (Type type : types){
+                                                                                if (paramType.equals(type)) {
+                                                                                        synchronized (STATE) {
+                                                                                                if (STATE.dependentPlugins.containsKey(pl)) {
+                                                                                                        STATE.dependentPlugins.put(pl, true);
+                                                                                                }
+                                                                                        }
+                                                                                        break param;
+                                                                                }
+                                                                        }
+                                                                }
+                                                        }
+                                                }
+                                        }
+
+                                        if (metrics != null) {
+                                                metrics.addCustomChart(new DrilldownPie("deprecated", () -> {
+                                                        Map<String, Map<String, Integer>> map = new HashMap<>();
+                                                        synchronized (STATE) {
+                                                                for (Plugin tracked : STATE.dependentPlugins.keySet()){
+                                                                        String deprecated = STATE.dependentPlugins.get(tracked) ? "yes" : "no";
+                                                                        Map<String, Integer> entry = new HashMap<>();
+                                                                        entry.put(tracked.getDescription().getFullName(), 1);
+                                                                        map.put(deprecated, entry);
+                                                                }
+                                                        }
+                                                        return map;
+                                                }));
+                                        }
+                                }
+                        }, 1);
+
+                        if (pluginManaged) {
+                                STATE.updateCheckTask = Scheduler.runAsyncTimer(new Runnable() {
+
+                                        @Override
+                                        public void run() {
+                                                try {
+                                                        if (Updater.checkUpdate("19287", owningPlugin.getDescription().getVersion())){
+                                                                Bukkit.getLogger().info(String.format("[%s] New update available!", owningPlugin.getDescription().getName()));
+                                                        }
+                                                } catch (IOException e) {
+                                                        Bukkit.getLogger().info(String.format("[%s] Cannot receive update from Spigot resource page!", owningPlugin.getDescription().getName()));
+                                                }
+                                        }
+                                }, 20*10, 20 * 60 * 60 * 24);
+                        }
+                }
+        }
+
+        private static void shutdownInternal() {
+                synchronized (STATE) {
+                        if (!STATE.initialized) {
+                                return;
+                        }
+
+                        STATE.disabling = true;
+                        if (STATE.dependencyScanTask != null) {
+                                STATE.dependencyScanTask.cancel();
+                                STATE.dependencyScanTask = null;
+                        }
+
+                        if (STATE.updateCheckTask != null) {
+                                STATE.updateCheckTask.cancel();
+                                STATE.updateCheckTask = null;
+                        }
+
+                        if (!Scheduler.isFolia() && STATE.owningPlugin != null) {
+                                Bukkit.getScheduler().cancelTasks(STATE.owningPlugin);
+                                List<BukkitWorker> workers = Bukkit.getScheduler().getActiveWorkers();
+                                for (BukkitWorker worker : workers){
+                                        if (!worker.getOwner().equals(STATE.owningPlugin))
+                                                continue;
+                                        worker.getThread().interrupt();
+                                }
+                        }
+                        if (NoteBlockPlayerMain.plugin != null) {
+                                NoteBlockPlayerMain.plugin.onDisable();
+                        }
+
+                        STATE.playingSongs.clear();
+                        STATE.playerVolume.clear();
+                        STATE.dependentPlugins.clear();
+
+                        STATE.pluginInstance = null;
+                        STATE.owningPlugin = null;
+                        STATE.initialized = false;
+                        STATE.disabling = false;
+                }
+        }
 
 	/**
 	 * Returns true if a Player is currently receiving a song
@@ -51,10 +188,10 @@ public class NoteBlockAPI extends JavaPlugin {
 	 * @param uuid
 	 * @return is receiving a song
 	 */
-	public static boolean isReceivingSong(UUID uuid) {
-		ArrayList<SongPlayer> songs = plugin.playingSongs.get(uuid);
-		return (songs != null && !songs.isEmpty());
-	}
+        public static boolean isReceivingSong(UUID uuid) {
+                ArrayList<SongPlayer> songs = STATE.playingSongs.get(uuid);
+                return (songs != null && !songs.isEmpty());
+        }
 
 	/**
 	 * Stops the song for a Player
@@ -68,15 +205,15 @@ public class NoteBlockAPI extends JavaPlugin {
 	 * Stops the song for a Player
 	 * @param uuid
 	 */
-	public static void stopPlaying(UUID uuid) {
-		ArrayList<SongPlayer> songs = plugin.playingSongs.get(uuid);
-		if (songs == null) {
-			return;
-		}
-		for (SongPlayer songPlayer : songs) {
-			songPlayer.removePlayer(uuid);
-		}
-	}
+        public static void stopPlaying(UUID uuid) {
+                ArrayList<SongPlayer> songs = STATE.playingSongs.get(uuid);
+                if (songs == null) {
+                        return;
+                }
+                for (SongPlayer songPlayer : songs) {
+                        songPlayer.removePlayer(uuid);
+                }
+        }
 
 	/**
 	 * Sets the volume for a given Player
@@ -92,9 +229,9 @@ public class NoteBlockAPI extends JavaPlugin {
 	 * @param uuid
 	 * @param volume
 	 */
-	public static void setPlayerVolume(UUID uuid, byte volume) {
-		plugin.playerVolume.put(uuid, volume);
-	}
+        public static void setPlayerVolume(UUID uuid, byte volume) {
+                STATE.playerVolume.put(uuid, volume);
+        }
 
 	/**
 	 * Gets the volume for a given Player
@@ -111,141 +248,85 @@ public class NoteBlockAPI extends JavaPlugin {
 	 * @return volume (byte)
 	 */
 	public static byte getPlayerVolume(UUID uuid) {
-		Byte byteObj = plugin.playerVolume.get(uuid);
-		if (byteObj == null) {
-			byteObj = 100;
-			plugin.playerVolume.put(uuid, byteObj);
-		}
-		return byteObj;
-	}
+                Byte byteObj = STATE.playerVolume.get(uuid);
+                if (byteObj == null) {
+                        byteObj = 100;
+                        STATE.playerVolume.put(uuid, byteObj);
+                }
+                return byteObj;
+        }
 	
 	public static ArrayList<SongPlayer> getSongPlayersByPlayer(Player player){
 		return getSongPlayersByPlayer(player.getUniqueId());
 	}
 	
 	public static ArrayList<SongPlayer> getSongPlayersByPlayer(UUID player){
-		return plugin.playingSongs.get(player);
-	}
+                return STATE.playingSongs.get(player);
+        }
 	
 	public static void setSongPlayersByPlayer(Player player, ArrayList<SongPlayer> songs){
 		setSongPlayersByPlayer(player.getUniqueId(), songs);
 	}
 	
-	public static void setSongPlayersByPlayer(UUID player, ArrayList<SongPlayer> songs){
-		plugin.playingSongs.put(player, songs);
-	}
+        public static void setSongPlayersByPlayer(UUID player, ArrayList<SongPlayer> songs){
+                STATE.playingSongs.put(player, songs);
+        }
 
-	@Override
-	public void onEnable() {
-		plugin = this;
+        public static void initializeAPI(JavaPlugin plugin) {
+                ensureInitialized(plugin, false);
+        }
 
-                for (Plugin pl : getServer().getPluginManager().getPlugins()){
-			if (pl.getDescription().getDepend().contains("NoteBlockAPI") || pl.getDescription().getSoftDepend().contains("NoteBlockAPI")){
-				dependentPlugins.put(pl, false);
-			}
-		}
-		
-		Metrics metrics = new Metrics(this, 1083);
-		
-		
-		new NoteBlockPlayerMain().onEnable();
-		
-		dependencyScanTask = Scheduler.runLater(new Runnable() {
+        public static void shutdownAPI() {
+                shutdownInternal();
+        }
 
-			@Override
-			public void run() {
-				Plugin[] plugins = getServer().getPluginManager().getPlugins();
-			Type[] types = new Type[]{PlayerRangeStateChangeEvent.class, SongDestroyingEvent.class, SongEndEvent.class, SongStoppedEvent.class };
-			for (Plugin plugin : plugins) {
-			    ArrayList<RegisteredListener> rls = HandlerList.getRegisteredListeners(plugin);
-			    for (RegisteredListener rl : rls) {
-				Method[] methods = rl.getListener().getClass().getDeclaredMethods();
-				for (Method m : methods) {
-				    Type[] params = m.getParameterTypes();
-				    param:
-				    for (Type paramType : params) {
-					for (Type type : types){
-						if (paramType.equals(type)) {
-							dependentPlugins.put(plugin, true);
-							break param;
-						}
-					}
-				    }
-				}
+        @Override
+        public void onEnable() {
+                ensureInitialized(this, true);
+        }
 
-			    }
-			}
+        @Override
+        public void onDisable() {
+                shutdownInternal();
+        }
 
-			metrics.addCustomChart(new DrilldownPie("deprecated", () -> {
-				Map<String, Map<String, Integer>> map = new HashMap<>();
-				for (Plugin pl : dependentPlugins.keySet()){
-					String deprecated = dependentPlugins.get(pl) ? "yes" : "no";
-					Map<String, Integer> entry = new HashMap<>();
-					entry.put(pl.getDescription().getFullName(), 1);
-					map.put(deprecated, entry);
-				}
-				return map;
-			    }));
-			}
-		}, 1);
+        public void doSync(Runnable runnable) {
+                Scheduler.run(runnable);
+        }
 
-		updateCheckTask = Scheduler.runAsyncTimer(new Runnable() {
+        public void doAsync(Runnable runnable) {
+                Scheduler.runAsync(runnable);
+        }
 
-			@Override
-			public void run() {
-				try {
-					if (Updater.checkUpdate("19287", getDescription().getVersion())){
-						Bukkit.getLogger().info(String.format("[%s] New update available!", plugin.getDescription().getName()));
-					}
-				} catch (IOException e) {
-					Bukkit.getLogger().info(String.format("[%s] Cannot receive update from Spigot resource page!", plugin.getDescription().getName()));
-				}
-			}
-		}, 20*10, 20 * 60 * 60 * 24);
-	}
+        public boolean isDisabling() {
+                return STATE.disabling;
+        }
 
-	@Override
-	public void onDisable() {    	
-		disabling = true;
-		if (dependencyScanTask != null) {
-			dependencyScanTask.cancel();
-			dependencyScanTask = null;
-		}
+        public static void doSync(Runnable runnable) {
+                Scheduler.run(runnable);
+        }
 
-		if (updateCheckTask != null) {
-			updateCheckTask.cancel();
-			updateCheckTask = null;
-		}
+        public static void doAsync(Runnable runnable) {
+                Scheduler.runAsync(runnable);
+        }
 
-		if (!Scheduler.isFolia()) {
-			Bukkit.getScheduler().cancelTasks(this);
-			List<BukkitWorker> workers = Bukkit.getScheduler().getActiveWorkers();
-			for (BukkitWorker worker : workers){
-				if (!worker.getOwner().equals(this))
-					continue;
-				worker.getThread().interrupt();
-			}
-		}
-		NoteBlockPlayerMain.plugin.onDisable();
-	}
+        public static boolean isDisablingAPI() {
+                synchronized (STATE) {
+                        return STATE.disabling;
+                }
+        }
 
-	public void doSync(Runnable runnable) {
-		Scheduler.run(runnable);
-	}
+        public static NoteBlockAPI getAPI(){
+                return STATE.pluginInstance;
+        }
 
-	public void doAsync(Runnable runnable) {
-		Scheduler.runAsync(runnable);
-	}
+        public static Plugin getOwningPlugin() {
+                synchronized (STATE) {
+                        return STATE.owningPlugin;
+                }
+        }
 
-	public boolean isDisabling() {
-		return disabling;
-	}
-	
-	public static NoteBlockAPI getAPI(){
-		return plugin;
-	}
-	
-	protected void handleDeprecated(StackTraceElement[] ste){
+        protected void handleDeprecated(StackTraceElement[] ste){
 		int pom = 1;
 		String clazz = ste[pom].getClassName();
 		while (clazz.startsWith("com.xxmicloxx.NoteBlockAPI")){
@@ -253,8 +334,10 @@ public class NoteBlockAPI extends JavaPlugin {
 			clazz = ste[pom].getClassName();
 		}
 		String[] packageParts = clazz.split("\\.");
-		ArrayList<Plugin> plugins = new ArrayList<Plugin>();
-		plugins.addAll(dependentPlugins.keySet());
+                ArrayList<Plugin> plugins = new ArrayList<Plugin>();
+                synchronized (STATE) {
+                        plugins.addAll(STATE.dependentPlugins.keySet());
+                }
 		
 		ArrayList<Plugin> notResult = new ArrayList<Plugin>();
 		parts:
@@ -278,8 +361,10 @@ public class NoteBlockAPI extends JavaPlugin {
 		plugins.removeAll(notResult);
 		notResult.clear();
 		if (plugins.size() == 1){
-			dependentPlugins.put(plugins.get(0), true);
-		}
-	}
-	
+                        synchronized (STATE) {
+                                STATE.dependentPlugins.put(plugins.get(0), true);
+                        }
+                }
+        }
+
 }

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/SongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/SongPlayer.java
@@ -51,7 +51,10 @@ public abstract class SongPlayer {
 	}
 
 	public SongPlayer(Song song, SoundCategory soundCategory) {
-		NoteBlockAPI.getAPI().handleDeprecated(Thread.currentThread().getStackTrace());
+                NoteBlockAPI api = NoteBlockAPI.getAPI();
+                if (api != null) {
+                        api.handleDeprecated(Thread.currentThread().getStackTrace());
+                }
 		
 		this.song = song;
 		this.soundCategory = soundCategory;
@@ -241,7 +244,7 @@ public abstract class SongPlayer {
 				long startTime = System.currentTimeMillis();
 				lock.lock();
 				try {
-					if (destroyed || NoteBlockAPI.getAPI().isDisabling()){
+                                    if (destroyed || NoteBlockAPI.isDisablingAPI()){
 						break;
 					}
 

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/songplayer/SongPlayer.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/songplayer/SongPlayer.java
@@ -42,14 +42,12 @@ public abstract class SongPlayer {
 	protected RepeatMode repeat = RepeatMode.NO;
 	protected boolean random = false;
 
-	protected Map<Song, Boolean> songQueue = new ConcurrentHashMap<Song, Boolean>(); //True if already played
+        protected Map<Song, Boolean> songQueue = new ConcurrentHashMap<Song, Boolean>(); //True if already played
 
-	private final Lock lock = new ReentrantLock();
-	private final Random rng = new Random();
+        private final Lock lock = new ReentrantLock();
+        private final Random rng = new Random();
 
-	protected NoteBlockAPI plugin;
-
-	protected SoundCategory soundCategory;
+        protected SoundCategory soundCategory;
 	protected ChannelMode channelMode = new MonoMode();
 	protected boolean enable10Octave = false;
 
@@ -77,11 +75,10 @@ public abstract class SongPlayer {
 
 	public SongPlayer(Playlist playlist, SoundCategory soundCategory, boolean random){
 		this.playlist = playlist;
-		this.random = random;
-		this.soundCategory = soundCategory;
-		plugin = NoteBlockAPI.getAPI();
-		
-		fadeIn = new Fade(FadeType.NONE, 60);
+                this.random = random;
+                this.soundCategory = soundCategory;
+
+                fadeIn = new Fade(FadeType.NONE, 60);
 		fadeIn.setFadeStart((byte) 0);
 		fadeIn.setFadeTarget(volume);
 		
@@ -132,10 +129,8 @@ public abstract class SongPlayer {
 		
 		fadeOut = new Fade(FadeType.NONE, 60);
 		fadeOut.setFadeStart(volume);
-		fadeOut.setFadeTarget((byte) 0);
-
-		plugin = NoteBlockAPI.getAPI();
-	}
+                fadeOut.setFadeTarget((byte) 0);
+        }
 
 	void update(String key, Object value){
 		switch (key){
@@ -309,12 +304,12 @@ public abstract class SongPlayer {
 	 * Starts this SongPlayer
 	 */
 	private void start() {
-		plugin.doAsync(() -> {
+            NoteBlockAPI.doAsync(() -> {
 			while (!destroyed) {
 				long startTime = System.currentTimeMillis();
 				lock.lock();
 				try {
-					if (destroyed || NoteBlockAPI.getAPI().isDisabling()){
+                                    if (destroyed || NoteBlockAPI.isDisablingAPI()){
 						break;
 					}
 
@@ -325,7 +320,7 @@ public abstract class SongPlayer {
 								fading = false;
 								if (!playing) {
 									SongStoppedEvent event = new SongStoppedEvent(this);
-									plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                                                                    NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 									volume = fadeIn.getFadeTarget();
 									continue;
 								}
@@ -357,7 +352,7 @@ public abstract class SongPlayer {
 							volume = fadeIn.getFadeTarget();
 							if (repeat == RepeatMode.ONE){
 								SongLoopEvent event = new SongLoopEvent(this);
-								plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                                                            NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 
 								if (!event.isCancelled()) {
 									continue;
@@ -383,7 +378,7 @@ public abstract class SongPlayer {
 										CallUpdate("song", song);
 										if (repeat == RepeatMode.ALL) {
 											SongLoopEvent event = new SongLoopEvent(this);
-											plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                                                                                    NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 
 											if (!event.isCancelled()) {
 												continue;
@@ -395,7 +390,7 @@ public abstract class SongPlayer {
 
 										CallUpdate("song", song);
 										SongNextEvent event = new SongNextEvent(this);
-										plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                                                                            NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 										continue;
 									}
 								} else {
@@ -404,7 +399,7 @@ public abstract class SongPlayer {
 										song = playlist.get(actualSong);
 										CallUpdate("song", song);
 										SongNextEvent event = new SongNextEvent(this);
-										plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                                                                            NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 										continue;
 									} else {
 										actualSong = 0;
@@ -412,7 +407,7 @@ public abstract class SongPlayer {
 										CallUpdate("song", song);
 										if (repeat == RepeatMode.ALL) {
 											SongLoopEvent event = new SongLoopEvent(this);
-											plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                                                                                    NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 
 											if (!event.isCancelled()) {
 												continue;
@@ -423,7 +418,7 @@ public abstract class SongPlayer {
 							}
 							playing = false;
 							SongEndEvent event = new SongEndEvent(this);
-							plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                                                    NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 							if (autoDestroy) {
 								destroy();
 							}
@@ -431,7 +426,7 @@ public abstract class SongPlayer {
 						}
 						CallUpdate("tick", tick);
 						
-						plugin.doSync(() -> {
+                                            NoteBlockAPI.doSync(() -> {
 							try {
 								for (UUID uuid : playerList.keySet()) {
 									Player player = Bukkit.getPlayer(uuid);
@@ -599,7 +594,7 @@ public abstract class SongPlayer {
 		lock.lock();
 		try {
 			SongDestroyingEvent event = new SongDestroyingEvent(this);
-			plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                    NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 			//Bukkit.getScheduler().cancelTask(threadId);
 			if (event.isCancelled()) {
 				return;
@@ -654,7 +649,7 @@ public abstract class SongPlayer {
 			volume = fadeIn.getFadeTarget();
 			if (!playing) {
 				SongStoppedEvent event = new SongStoppedEvent(this);
-				plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                            NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 			}
 		}
 
@@ -713,7 +708,7 @@ public abstract class SongPlayer {
 			NoteBlockAPI.setSongPlayersByPlayer(player, songs);
 			if (playerList.isEmpty() && autoDestroy) {
 				SongEndEvent event = new SongEndEvent(this);
-				plugin.doSync(() -> Bukkit.getPluginManager().callEvent(event));
+                            NoteBlockAPI.doSync(() -> Bukkit.getPluginManager().callEvent(event));
 				destroy();
 			}
 		} finally {

--- a/src/main/java/com/xxmicloxx/NoteBlockAPI/utils/Scheduler.java
+++ b/src/main/java/com/xxmicloxx/NoteBlockAPI/utils/Scheduler.java
@@ -208,11 +208,15 @@ public final class Scheduler {
     }
 
     private static Plugin getPlugin() {
-        return NoteBlockAPI.getAPI();
+        Plugin plugin = NoteBlockAPI.getOwningPlugin();
+        if (plugin == null) {
+            throw new IllegalStateException("NoteBlockAPI has not been initialized. Call NoteBlockAPI.initializeAPI(JavaPlugin) before using the scheduler.");
+        }
+        return plugin;
     }
 
     private static Logger getLogger() {
-        Plugin plugin = NoteBlockAPI.getAPI();
+        Plugin plugin = NoteBlockAPI.getOwningPlugin();
         return plugin != null ? plugin.getLogger() : Bukkit.getLogger();
     }
 


### PR DESCRIPTION
## Summary
- add an internal ApiState that exposes a new initializeAPI/shutdownAPI pathway for embedded usage
- refactor song player implementations to use the static scheduler helpers and guard against a missing NoteBlockAPI plugin instance
- update the scheduler to obtain the owning plugin via NoteBlockAPI and throw a descriptive error when the API has not been initialized

## Testing
- ./mvnw -q -DskipTests package *(fails: unable to download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e45a331e908332b9d5e84dc0263b6e